### PR TITLE
例外処理のバグ修正

### DIFF
--- a/scripts/sample_DB2.js
+++ b/scripts/sample_DB2.js
@@ -55,7 +55,7 @@ function init() {
         try{
             execute("DROP TABLE sample01");
         }catch(e){
-            if(e.toSource().indexOf("SQLSTATE: 42704") >= 0){
+            if(e.javaException instanceof java.sql.SQLException && e.javaException.getSQLState() == '42704'){
                 info("DROP TABLE failed. Table is not found.");
             }else{
                 throw e;


### PR DESCRIPTION
DROP TABLEに失敗した際の例外処理にバグがあったのを修正。
SQLSTATE: 42704でも、それ以外の例外でも、INFOだけ出して
処理が継続されてしまっていたのを、42704以外なら終了する
ように修正した。
